### PR TITLE
add docker://

### DIFF
--- a/actions/yq/action.yml
+++ b/actions/yq/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'mikefarah/yq:3'
+  image: 'docker://mikefarah/yq:3'
   args:
   - sh
   - -c


### PR DESCRIPTION
it works without `docker://` if it's local to the repo. but `docker://` is needed if it's not. See https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/metadata-syntax-for-github-actions#example-using-public-docker-registry-container