### PR TITLE
Remove spurious popd; preserve whitespace creating new version line

### DIFF
--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -60,7 +60,7 @@ else
 fi
 
 echo $log
-popd 
+
 # this will bump the semvar using the default bump level,
 # or it will simply pass if the default was "none"
 function default-bump {
@@ -140,7 +140,7 @@ else
     if [ -z "$version_line" ]; then
         echo "No version line found; no bump of version file."
     else
-        new_line=$(echo $version_line | sed -E -e "s/(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)/\1${version_new}\3/")
+        new_line=$(echo "$version_line" | sed -E -e "s/(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)/\1${version_new}\3/")
         sed -E -i.bak -e "s/${version_line}/${new_line}/" $version_file_path
     fi
     git config --global user.email "robot@terra.team"


### PR DESCRIPTION
There is a stray `popd` in the script that always generates a warning.
The creation of the `new_line` loses the whitespace of the version line.
Surrounding the echo with double quotes fixes this.
