### PR TITLE
PF-637 Add hotfix bumping support

### DIFF
--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # config
-default_semvar_bump=${DEFAULT_BUMP:-minor}
+default_semvar_bump=${DEFAULT_BUMP:-patch}
+override_semvar_bump=${OVERRIDE_BUMP}
 with_v=${WITH_V:-false}
-release_branches=${RELEASE_BRANCHES:-master}
-custom_tag=${CUSTOM_TAG}
+release_branches=${RELEASE_BRANCHES:-main}
+hotfix_branches=${HOTFIX_BRANCHES:-hotfix.*}
 source=${SOURCE:-.}
 dryrun=${DRY_RUN:-false}
 initial_version=${INITIAL_VERSION:-0.0.0}
@@ -12,20 +13,37 @@ tag_context=${TAG_CONTEXT:-repo}
 version_file_path=${VERSION_FILE_PATH}
 version_line_match=${VERSION_LINE_MATCH}
 version_suffix=${VERSION_SUFFIX}
+hotfix_version=${HOTFIX_VERSION}
 
 cd ${GITHUB_WORKSPACE}/${source}
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
-pre_release="true"
-IFS=',' read -ra branch <<< "$release_branches"
+hotfix_release="false"
+IFS=',' read -ra branch <<< "$hotfix_branches"
 for b in "${branch[@]}"; do
     echo "Is $b a match for ${current_branch}"
     if [[ "${current_branch}" =~ $b ]]
     then
-        pre_release="false"
+        hotfix_release="true"
     fi
 done
+echo "hotfix_release = $hotfix_release"
+
+# By definition, if it is a hotfix release, it is not pre_release
+if $hotfix_release; then
+    pre_release="false"
+else
+    pre_release="true"
+    IFS=',' read -ra branch <<< "$release_branches"
+    for b in "${branch[@]}"; do
+        echo "Is $b a match for ${current_branch}"
+        if [[ "${current_branch}" =~ $b ]]
+        then
+            pre_release="false"
+        fi
+    done
+fi    
 echo "pre_release = $pre_release"
 
 # fetch tags
@@ -39,6 +57,7 @@ case "$tag_context" in
 esac
 
 # get current commit hash for tag
+# on the initial use, this shows usage, because $tag is empty. The logic below still works.
 tag_commit=$(git rev-list -n 1 $tag)
 
 # get current commit hash
@@ -61,49 +80,73 @@ fi
 
 echo $log
 
-# this will bump the semvar using the default bump level,
-# or it will simply pass if the default was "none"
-function default-bump {
-  if [ "$default_semvar_bump" == "none" ]; then
-    echo "Default bump was set to none. Skipping..."
-    exit 0
-  else
-    semver bump "${default_semvar_bump}" $tag
-  fi
-}
+HOTFIX_REGEX="^hotfix\\.(0|[1-9][0-9]*)$"
+if $hotfix_release; then
+    # For hotfix release, we compute the hotfix string and do not bump any fields in the version number part
+    if [ -n "$hotfix_version" ]; then
+        # Specific hotfix version specified
+        hotfix_string="hotfix.${hotfix_version}"
+    else
+        # Compute the hotfix string by trying to read the version from the prerel
+        # If it isn't there or isn't in our hotfix format, then we use hotfix.0
+        hotfix_string="hotfix.0"
+        prerel=$(semver get prerel $tag)
+        echo "get prerel is '$prerel'"
+        if [ -n "$prerel" ]; then
+            # We have a prerel. See if it is a proper hotfix
+            if [[ "$prerel" =~ $HOTFIX_REGEX ]]; then
+                hotfix_incr="$((${BASH_REMATCH[1]} + 1))"
+                hotfix_string="hotfix.$hotfix_incr"
+            else
+                echo "prerel did not match hotfix regex"
+            fi
+        fi
+    fi
+    new=$(semver bump prerel $hotfix_string $tag)
+    part="hotfix"
+else           
+    # For non-hotfix, we compute the new version
+    # If there is an override, use that
+    if [ -n "$override_semvar_bump" ]; then
+        part=$override_semvar_bump
+    else
+        # No override, check the commit message.
+        # Failing that, use the default.
+        case "$log" in
+            *#major* ) part="major";;
+            *#minor* ) part="minor";;
+            *#patch* ) part="patch";;
+            * )
+                if [ "$default_semvar_bump" == "none" ]; then
+                    echo "Default bump was set to none. Skipping..."
+                    exit 0
+                else
+                    part="${default_semvar_bump}"
+                fi
+        esac
 
-# get commit logs and determine home to bump the version
-# supports #major, #minor, #patch (anything else will be 'minor')
-case "$log" in
-    *#major* ) new=$(semver bump major $tag); part="major";;
-    *#minor* ) new=$(semver bump minor $tag); part="minor";;
-    *#patch* ) new=$(semver bump patch $tag); part="patch";;
-    * ) new=$(default-bump); part=$default_semvar_bump;;
-esac
+        new=$(semver bump $part $tag)
+    fi
+fi
 
-echo $part
+echo "Updated semver part $part"
 
 # did we get a new tag?
 if [ ! -z "$new" ]
 then
-	# prefix with 'v'
-	if $with_v
-	then
-			new="v$new"
-	fi
-
-	if $pre_release
-	then
-			new="$new-${commit:0:7}"
-	fi
+    # prefix with 'v'
+    if $with_v
+    then
+	new="v$new"
+    fi
+    
+    if $pre_release
+    then
+	new="$new-${commit:0:7}"
+    fi
 fi
 
-if [ ! -z $custom_tag ]
-then
-    new="$custom_tag"
-fi
-
-echo $new
+echo "New tag is $new"
 
 # set outputs
 echo ::set-output name=new_tag::$new


### PR DESCRIPTION
This work extends the bumper github action to enable support for hotfix labeling as proposed here [Software Versioning Proposal](https://docs.google.com/document/d/1eT-k48cxk74kScxP4iscg9lYETziK1zOivC1rnEpCzM/edit#heading=h.4govmyd845l5)

I have tested this as a standalone action in a private project. I believe it is upward compatible with current usage.
