### PR TITLE
[PF-898] Compute the new version when OVERRIDE_BUMP is present

### DIFF
--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -106,7 +106,8 @@ if $hotfix_release; then
     part="hotfix"
 else           
     # For non-hotfix, we compute the new version
-    # If there is an override, use that
+    # If there is an override for what part to bump, use that. If there is a #xyz in the log message, use that.
+    # Othewise, use the default part.
     if [ -n "$override_semvar_bump" ]; then
         part=$override_semvar_bump
     else
@@ -124,9 +125,8 @@ else
                     part="${default_semvar_bump}"
                 fi
         esac
-
-        new=$(semver bump $part $tag)
     fi
+    new=$(semver bump $part $tag)
 fi
 
 echo "Updated semver part $part"


### PR DESCRIPTION
There was a logic error in one branch of an if so that the new version number was not calculated.
Small change. I tested the shell script in place.
