### PR TITLE
DDO-1530 Adapt chart-releaser action to publish charts to GCS bucket in tandem

### DIFF
--- a/actions/chart-releaser/Dockerfile
+++ b/actions/chart-releaser/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 
 ARG YQ_VERSION=3.3.2
 ARG YQ_SHA256=0b0700cfee1d642a0a19f8f9261b2f0a11b7174ef8bcd39e9ed334d9519f0125

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -221,7 +221,7 @@ setup_gcs() {
   gcs_sa_key_file="sa-key.json"
   echo $gcs_sa_key_b64 | base64 -d > "$gcs_sa_key_file"
   # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
-  gcloud auth active-service-account "${gcs_sa_email}" --key-file="${gcs_sa_key_file}"
+  gcloud auth activate-service-account "${gcs_sa_email}" --key-file="${gcs_sa_key_file}"
   eok 'Authed to GCP'
 }
 

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -15,7 +15,7 @@ set_vars() {
         if [ -z ${!varCaps+x} ]; then
             eval "$var"=$(yq r "$config_file" "$var.default")
         else
-            eval "$var"="${!varCaps}"
+            eval "$var"="$( printf "%q" ${!varCaps} )"
         fi
     done
 }

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -166,10 +166,8 @@ release_charts_gcs() {
         return 0
     fi
 
-    einfo 'Releasing charts to GCS bucket...'
-    # TODO
-    gsutil cp .cr-release-packages/* gs:///terra-helm
-    # cr upload -o "$github_owner" -r "$github_repo" -t "$github_token" -c "$(git rev-parse HEAD)"
+    einfo 'Uploading new charts to GCS bucket...'
+    gsutil cp .cr-release-packages/*.tgz gs://terra-helm
     eok 'Charts released'
 }
 
@@ -203,8 +201,16 @@ update_index_gcs() {
         return 0
     fi
 
-    einfo 'Updating charts repo index in GCS bucket...'
-    # TODO
+    einfo 'Updating repo index in GCS bucket...'
+    gsutil cp "gs://${gcs_bucket}/index.yaml" .cr-release-packages/index.original.yaml || return $?
+
+    helm repo index \
+      .cr-release-packages \
+      --merge .cr-release-packages/index.original.yaml \
+      --url="https://${gcs_bucket}.storage.googleapis.com/" || return $?
+
+    gsutil cp .cr-release-packages/index.yaml  "gs://${gcs_bucket}/index.yaml" || return $?
+
     eok 'Index updated'
 }
 

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -161,7 +161,7 @@ release_charts_cr() {
 }
 
 release_charts_gcs() {
-    if [[ "$gcs_enabled" != "true" ]]; then
+    if [[ "$gcs_publishing_enabled" != "true" ]]; then
         einfo "GCS publishing disabled, won't upload charts to GCS bucket"
         return 0
     fi
@@ -197,7 +197,7 @@ update_index_cr() {
 }
 
 update_index_gcs() {
-    if [[ "$gcs_enabled" != "true" ]]; then
+    if [[ "$gcs_publishing_enabled" != "true" ]]; then
         einfo "GCS publishing disabled, won't update index.yaml in GCS bucket"
         return 0
     fi
@@ -212,7 +212,7 @@ setup() {
 }
 
 setup_gcs() {
-  if [[ "$gcs_enabled" != "true" ]]; then
+  if [[ "$gcs_publishing_enabled" != "true" ]]; then
       einfo "GCS publishing disabled, won't set up up GCP auth"
       return 0
   fi

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -15,7 +15,7 @@ set_vars() {
         if [ -z ${!varCaps+x} ]; then
             eval "$var"=$(yq r "$config_file" "$var.default")
         else
-            eval "$var"="$( printf "%q" ${!varCaps} )"
+            eval "$var"="${!varCaps}"
         fi
     done
 }
@@ -219,8 +219,6 @@ setup_gcs() {
     fi
 
     einfo 'Authenticating to GCP...'
-    gcs_sa_key_file="helm-gcs-sa-key.json"
-    echo "$gcs_sa_key" > "$gcs_sa_key_file"
     # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
     gcloud auth activate-service-account --key-file="${gcs_sa_key_file}"
     eok 'Authed to GCP'

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -168,6 +168,7 @@ release_charts_gcs() {
 
     einfo 'Releasing charts to GCS bucket...'
     # TODO
+    gsutil cp .cr-release-packages/* gs:///terra-helm
     # cr upload -o "$github_owner" -r "$github_repo" -t "$github_token" -c "$(git rev-parse HEAD)"
     eok 'Charts released'
 }
@@ -218,10 +219,10 @@ setup_gcs() {
   fi
 
   einfo 'Authenticating to GCP...'
-  gcs_sa_key_file="sa-key.json"
-  echo $gcs_sa_key_b64 | base64 -d > "$gcs_sa_key_file"
+  gcs_sa_key_file="helm-gcs-sa-key.json"
+  echo "$gcs_sa_key" > "$gcs_sa_key_file"
   # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
-  gcloud auth activate-service-account "${gcs_sa_email}" --key-file="${gcs_sa_key_file}"
+  gcloud auth activate-service-account --key-file="${gcs_sa_key_file}"
   eok 'Authed to GCP'
 }
 

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -150,8 +150,8 @@ package_chart() {
 }
 
 release_charts() {
-  release_charts_cr || return $?
-  release_charts_gcs
+    release_charts_cr || return $?
+    release_charts_gcs
 }
 
 release_charts_cr() {
@@ -209,21 +209,21 @@ update_index_gcs() {
 }
 
 setup() {
-  setup_gcs
+    setup_gcs
 }
 
 setup_gcs() {
-  if [[ "$gcs_publishing_enabled" != "true" ]]; then
-      einfo "GCS publishing disabled, won't set up up GCP auth"
-      return 0
-  fi
+    if [[ "$gcs_publishing_enabled" != "true" ]]; then
+        einfo "GCS publishing disabled, won't set up up GCP auth"
+        return 0
+    fi
 
-  einfo 'Authenticating to GCP...'
-  gcs_sa_key_file="helm-gcs-sa-key.json"
-  echo "$gcs_sa_key" > "$gcs_sa_key_file"
-  # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
-  gcloud auth activate-service-account --key-file="${gcs_sa_key_file}"
-  eok 'Authed to GCP'
+    einfo 'Authenticating to GCP...'
+    gcs_sa_key_file="helm-gcs-sa-key.json"
+    echo "$gcs_sa_key" > "$gcs_sa_key_file"
+    # https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
+    gcloud auth activate-service-account --key-file="${gcs_sa_key_file}"
+    eok 'Authed to GCP'
 }
 
 colblk='\033[0;30m' # Black - Regular

--- a/actions/chart-releaser/inputs.yaml
+++ b/actions/chart-releaser/inputs.yaml
@@ -28,9 +28,6 @@ gcs_publishing_enabled:
 gcs_bucket:
   description: Name of the GCS bucket to publish to
   default: terra-helm
-gcs_sa_email:
-  description: Email for the GCP SA to use for publishing charts
-  default: ""
-gcs_sa_key_b64:
-  description: Base64-encoded GCP SA Key to use for publishing charts
+gcs_sa_key:
+  description: GCP SA Key to use for publishing charts
   default: ""

--- a/actions/chart-releaser/inputs.yaml
+++ b/actions/chart-releaser/inputs.yaml
@@ -22,7 +22,7 @@ github_owner:
 github_repo:
   description: GitHub repository name
   default: terra-helm
-gcs_enabled:
+gcs_publishing_enabled:
   description: Whether to publish to GCS bucket in addition to GitHub releases
   default: false
 gcs_bucket:

--- a/actions/chart-releaser/inputs.yaml
+++ b/actions/chart-releaser/inputs.yaml
@@ -28,6 +28,6 @@ gcs_publishing_enabled:
 gcs_bucket:
   description: Name of the GCS bucket to publish to
   default: terra-helm
-gcs_sa_key:
-  description: GCP SA Key to use for publishing charts
+gcs_sa_key_file:
+  description: Path to GCP SA Key to use for publishing charts
   default: ""

--- a/actions/chart-releaser/inputs.yaml
+++ b/actions/chart-releaser/inputs.yaml
@@ -22,3 +22,15 @@ github_owner:
 github_repo:
   description: GitHub repository name
   default: terra-helm
+gcs_enabled:
+  description: Whether to publish to GCS bucket in addition to GitHub releases
+  default: false
+gcs_bucket:
+  description: Name of the GCS bucket to publish to
+  default: terra-helm
+gcs_sa_email:
+  description: Email for the GCP SA to use for publishing charts
+  default: ""
+gcs_sa_key_b64:
+  description: Base64-encoded GCP SA Key to use for publishing charts
+  default: ""


### PR DESCRIPTION
Update the existing chart-releaser action to publish charts to a new GCS bucket, `terra-helm`, whenever it publishes a new chart to GitHub releases.

The work to merge terra-helm and terra-helmfile will involve rewriting the entrypoint.sh script in Golang, so I have not invested a ton of effort in refactoring it as part of this PR.

Tested here: https://github.com/broadinstitute/terra-helm/pull/484