### PR TITLE
DDO-1530 Disable caching on objects in the terra-helm GCS bucket

### DIFF
--- a/actions/chart-releaser/action.yml
+++ b/actions/chart-releaser/action.yml
@@ -6,6 +6,4 @@ branding:
   color: purple
 runs:
   using: 'docker'
-  # TODO: Revert before merging
-  # image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0
-  image: Dockerfile
+  image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0

--- a/actions/chart-releaser/action.yml
+++ b/actions/chart-releaser/action.yml
@@ -6,6 +6,4 @@ branding:
   color: purple
 runs:
   using: 'docker'
-  image: Dockerfile
-  # TODO revert before merging
-  # image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0
+  image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0

--- a/actions/chart-releaser/action.yml
+++ b/actions/chart-releaser/action.yml
@@ -6,4 +6,6 @@ branding:
   color: purple
 runs:
   using: 'docker'
-  image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0
+  # TODO: Revert before merging
+  # image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0
+  image: Dockerfile

--- a/actions/chart-releaser/action.yml
+++ b/actions/chart-releaser/action.yml
@@ -6,4 +6,6 @@ branding:
   color: purple
 runs:
   using: 'docker'
-  image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0
+  image: Dockerfile
+  # TODO revert before merging
+  # image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/chart-releaser:0.6.0

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -168,7 +168,7 @@ release_charts_gcs() {
 
     einfo 'Uploading new charts to GCS bucket...'
     # Set no-cache so that Helm always pulls down the latest copy of the file
-    gsutil -h "Cache-Control:no-cache" cp .cr-release-packages/*.tgz gs://terra-helm || return $?
+    gsutil -h "Cache-Control:no-cache" cp .cr-release-packages/*.tgz "gs://${gcs_bucket}" || return $?
     eok 'Charts released'
 }
 

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -166,7 +166,7 @@ release_charts_gcs() {
         return 0
     fi
 
-    einfo 'Uploading new charts to GCS bucket...'
+    einfo "Uploading new charts to GCS bucket: $( ls .cr-release-packages/*.tgz )"
     # Allow charts tgz files to be cached for up to 5 minutes
     gsutil -h "Cache-Control: public, max-age=300" \
       cp .cr-release-packages/*.tgz "gs://${gcs_bucket}/charts" || return $?

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -166,10 +166,12 @@ release_charts_gcs() {
         return 0
     fi
 
+    chart_dest="gs://${gcs_bucket}/charts"
     einfo "Uploading new charts to \"${chart_dest}\": $( ls .cr-release-packages/*.tgz )"
+
     # Allow charts tgz files to be cached for up to 5 minutes
     gsutil -h "Cache-Control: public, max-age=300" \
-      cp .cr-release-packages/*.tgz "gs://${gcs_bucket}/charts" || return $?
+      cp .cr-release-packages/*.tgz "$chart_dest" || return $?
 
     eok 'Charts released'
 }

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -167,7 +167,8 @@ release_charts_gcs() {
     fi
 
     einfo 'Uploading new charts to GCS bucket...'
-    gsutil cp .cr-release-packages/*.tgz gs://terra-helm
+    # Set no-cache so that Helm always pulls down the latest copy of the file
+    gsutil -h "Cache-Control:no-cache" cp .cr-release-packages/*.tgz gs://terra-helm || return $?
     eok 'Charts released'
 }
 
@@ -209,7 +210,8 @@ update_index_gcs() {
       --merge .cr-release-packages/index.original.yaml \
       --url="https://${gcs_bucket}.storage.googleapis.com/" || return $?
 
-    gsutil cp .cr-release-packages/index.yaml  "gs://${gcs_bucket}/index.yaml" || return $?
+    # Set no-cache so that Helm always pulls down the latest copy of the index
+    gsutil -h "Cache-Control:no-cache" cp .cr-release-packages/index.yaml  "gs://${gcs_bucket}/index.yaml" || return $?
 
     eok 'Index updated'
 }

--- a/actions/chart-releaser/entrypoint.sh
+++ b/actions/chart-releaser/entrypoint.sh
@@ -166,7 +166,7 @@ release_charts_gcs() {
         return 0
     fi
 
-    einfo "Uploading new charts to GCS bucket: $( ls .cr-release-packages/*.tgz )"
+    einfo "Uploading new charts to \"${chart_dest}\": $( ls .cr-release-packages/*.tgz )"
     # Allow charts tgz files to be cached for up to 5 minutes
     gsutil -h "Cache-Control: public, max-age=300" \
       cp .cr-release-packages/*.tgz "gs://${gcs_bucket}/charts" || return $?


### PR DESCRIPTION
After we cut over to the new GCS Helm repo, we started noticing an issue where after new Helm charts were published to the GCS bucket, attempted manifest renders would pull down an outdated `index.yaml` file and report that the new Helm chart was missing.

The root cause of this issue seems to be that GCS, by default, [sets a Cache-Control header of `public, max-age 3600`](https://cloud.google.com/storage/docs/metadata#caching_data) for all objects in a public bucket. This means that clients/CDNs/etc could cache an old index.yaml for up to an hour.

### Changes
  * Disable caching for `index.yaml`
  * Limit caching of helm chart files to 5 minutes. These chart files are never updated once released, so an even longer cache age would probably be fine.
  * Cleanup
    * Structure the GCS repo so that charts are kept in a subdirectory called `charts/` instead of in the repo root alongside the `index.yaml`
    * Better logging

### Testing

Tested in https://github.com/broadinstitute/terra-helm/pull/499