### PR TITLE
Stop reading tag versions with v prefix when with_v=false in bumper

### DIFF
--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -49,9 +49,14 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-# get latest tag that looks like a semver (with or without v)
+# get latest tag that looks like a semver (with or without v, using with_v)
+if $with_v; then
+  tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
+else
+  tag_pattern="refs/tags/[0-9]*.[0-9]*.[0-9]*"
+fi
 case "$tag_context" in
-    *repo*) tag=$(git for-each-ref --sort=-v:refname --count=1 --format '%(refname)' refs/tags/[0-9]*.[0-9]*.[0-9]* refs/tags/v[0-9]*.[0-9]*.[0-9]* | cut -d / -f 3-);;
+    *repo*) tag=$(git for-each-ref --sort=-v:refname --count=1 --format '%(refname)' "$tag_pattern" | cut -d / -f 3-);;
     *branch*) tag=$(git describe --tags --match "*[v0-9].*[0-9\.]" --abbrev=0);;
     * ) echo "Unrecognised context"; exit 1;;
 esac


### PR DESCRIPTION
This is a bit of a strange issue, but in https://github.com/DataBiosphere/terra-cloud-resource-lib we have a mix of versions with and without the `v` prefix (it used to be a manual process and people were inconsistent). Currently, the `bumper` GHA will find the highest semver-looking tag (with or without the `v` prefix) and bump from there, respecting the `WITH_V` flag in the output tag. This change makes `bumper` only read semver tags which match the current `WITH_V` setting.

With the existing approach, versions with a `v` come first when sorting by `-v:refname`. For example, with `terra-cloud-resource-lib`, this means that `bumper` always sees the latest version is `v1.0.3`, instead of `1.1.0`. `bumper` tries to publish `1.0.4` (no prefix) for every change, and it gets stuck because new bumps don't change the "latest" version that it sees. I think this will happen for any repo which sets `WITH_V=false` but has a previous release that looks like `vX.X.X`.