### PR TITLE
[TERRA-434] Replace set-output, fix version bug in bumper

### DIFF
--- a/actions/bumper/README.md
+++ b/actions/bumper/README.md
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Bump version and push tag

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -51,9 +51,9 @@ git fetch --tags
 
 # get latest tag that looks like a semver (with or without v, using with_v)
 if $with_v; then
-  tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
+    tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
 else
-  tag_pattern="refs/tags/[0-9]*.[0-9]*.[0-9]*"
+    tag_pattern="refs/tags/[0-9]*.[0-9]*.[0-9]*"
 fi
 case "$tag_context" in
     *repo*) tag=$(git for-each-ref --sort=-v:refname --count=1 --format '%(refname)' "$tag_pattern" | cut -d / -f 3-);;
@@ -70,7 +70,7 @@ commit=$(git rev-parse HEAD)
 
 if [ "$tag_commit" == "$commit" ]; then
     echo "No new commits since previous tag. Skipping..."
-    echo ::set-output name=tag::$tag
+    echo tag=$tag >> $GITHUB_OUTPUT
     exit 0
 fi
 
@@ -142,30 +142,29 @@ then
     # prefix with 'v'
     if $with_v
     then
-	new="v$new"
+        new="v$new"
     fi
     
     if $pre_release
     then
-	new="$new-${commit:0:7}"
+        new="$new-${commit:0:7}"
     fi
 fi
 
 echo "New tag is $new"
 
 # set outputs
-echo ::set-output name=new_tag::$new
-echo ::set-output name=part::$part
+echo new_tag=$new >> $GITHUB_OUTPUT
+echo part=$part >> $GITHUB_OUTPUT
 
 # use dry run to determine the next tag
 if $dryrun
 then
-    echo ::set-output name=tag::$tag
+    echo tag=$tag >> $GITHUB_OUTPUT
     exit 0
 fi 
 
-echo ::set-output name=tag::$new
-
+echo tag=$new >> $GITHUB_OUTPUT
 
 if $pre_release
 then

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -157,7 +157,7 @@ echo "New tag is $new"
 echo new_tag=$new >> $GITHUB_OUTPUT
 echo part=$part >> $GITHUB_OUTPUT
 
-# use dry run to determine the next tag
+# use dry run to determine the next tag
 if $dryrun
 then
     echo tag=$tag >> $GITHUB_OUTPUT
@@ -183,11 +183,18 @@ else
     else
         version_new=${new}-${version_suffix}
     fi
+
+    if $with_v; then
+        version_pattern="(.*)v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
+    else
+        version_pattern="(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
+    fi
+
     version_line=$(cat $version_file_path | grep -e "${version_line_match}")
     if [ -z "$version_line" ]; then
         echo "No version line found; no bump of version file."
     else
-        new_line=$(echo "$version_line" | sed -E -e "s/(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)/\1${version_new}\3/")
+        new_line=$(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
         sed -E -i.bak -e "s/${version_line}/${new_line}/" $version_file_path
     fi
     git config --global user.email "robot@terra.team"

--- a/actions/chart-releaser/README.md
+++ b/actions/chart-releaser/README.md
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: '0'

--- a/actions/preview/README.md
+++ b/actions/preview/README.md
@@ -17,7 +17,7 @@ This action contains the logic for managing the life-cycle of Terra preview envi
 |TERRA_HELMFILE_BRANCH|no|Branch of the terra-helmfile repo to use|master|
 
 ## Common output for all commands
-All of these commands output a Base64-encoded JSON with information about the environment and all services deployed using the GH actions `echo ::set-output name=output::[output string]` syntax
+All of these commands output a Base64-encoded JSON with information about the environment and all services deployed using the GH actions `echo output=[output string] >> $GITHUB_OUTPUT` syntax
 
 Example output (decoded from its original base64 output form):
 ```

--- a/actions/preview/entrypoint.sh
+++ b/actions/preview/entrypoint.sh
@@ -111,7 +111,7 @@ main() {
         eok "Test results for environment $env_id reported"
     fi
 
-    echo ::set-output name=output::$(yq r -j output.yaml | base64 | tr -d \\n)
+    echo output=$(yq r -j output.yaml | base64 | tr -d \\n) >> $GITHUB_OUTPUT
 }
 
 terraform_apply() {

--- a/actions/test-template/entrypoint.sh
+++ b/actions/test-template/entrypoint.sh
@@ -41,8 +41,8 @@ main() {
     local test_data_fmt='{"logs":"%s"}'
     local test_data=$(printf "$test_data_fmt" "$action_run_url")
     edumpvar test_data
-    echo ::set-output name=status::$pass
-    echo ::set-output name=testData::$(echo "$test_data" | base64 | tr -d \\n)
+    echo status=$pass >> $GITHUB_OUTPUT
+    echo testData=$(echo "$test_data" | base64 | tr -d \\n) >> $GITHUB_OUTPUT
 }
 
 colblk='\033[0;30m' # Black - Regular


### PR DESCRIPTION
1.  Replace set-output (deprecated) with echo (ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

2. Fix version bug in bumper
Problem statement: if option with_v: true, the new tag generated has a 'v' prefix (expected). However the sed command used to replace the version line in version file disregarded existing 'v' prefix and ends up adding a new 'v' prefix each time it runs  
fix: if 'with-v:true', add 'v' prefix to the version (source) pattern used in sed

```
>> version_new="v0.3.5-SNAPSHOT"
>> version_line="gradle.ext.releaseVersion='v0.0.1-test'"

# without changes
>> version_pattern="(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
>> echo $(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
gradle.ext.releaseVersion='vv0.3.5-SNAPSHOT'

#with changes in this PR
>> version_pattern="(.*)v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
>> echo $(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
gradle.ext.releaseVersion='v0.3.5-SNAPSHOT'
```

3. Minor formatting changes

