### PR TITLE
[TERRA-409] Fetch all changes/commits from a merge commit

### DIFF
--- a/actions/action-releaser/entrypoint.sh
+++ b/actions/action-releaser/entrypoint.sh
@@ -77,9 +77,12 @@ filter_actions() {
 }
 
 lookup_changed_actions() {
-    #look for changed files in the latest commit
+    # look for changed files in the latest commit
+    # merge commits have multiple parents, use '^@' to fetch all parents of the merge
+    # use variable to handle newline in git-rev-parse output
+    local commit_sha=$(git rev-parse HEAD^@)
     local changed_files
-    changed_files=$(git diff-tree --no-commit-id --name-only -r "$(git rev-parse HEAD)" -- $INPUT_ACTIONS_DIR)
+    changed_files=$(git diff-tree --no-commit-id --name-only -r $commit_sha -- $INPUT_ACTIONS_DIR)
     cut -d '/' -f '2' <<< "$changed_files" | uniq | filter_actions
 }
 

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -189,7 +189,6 @@ else
     else
         version_pattern="(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
     fi
-
     version_line=$(cat $version_file_path | grep -e "${version_line_match}")
     if [ -z "$version_line" ]; then
         echo "No version line found; no bump of version file."


### PR DESCRIPTION
Problem statement - 
function `lookup_changed_actions` in `actions/action-releaser/entrypoint.sh` fails to fetch all changed actions (files) if the latest commit onto the current branch is a merge commit 

current - 
```
github-actions (master) >> echo $(git rev-parse HEAD)
9f5c11e849628d7278f67eb4bc7a80c318105a31
```
this is a merge commit - https://github.com/DataBiosphere/github-actions/commit/9f5c11e849628d7278f67eb4bc7a80c318105a31
with parents `8c2fb3d87c6db648c209095d019dc131da48a31d` and '5a5004f79f088ed3fa8e1620419abb1c92ea0c82`

to get all the commits 
```
github-actions (master) >> echo $(git rev-parse HEAD^@)
8c2fb3d87c6db648c209095d019dc131da48a31d 5a5004f79f088ed3fa8e1620419abb1c92ea0c82
```

Also adding a newline to bumber/entrypoint.sh to trigger release for this action