### PR TITLE
Fix: handle both merge commits and direct commits in action-releaser

### DIFF
--- a/actions/action-releaser/entrypoint.sh
+++ b/actions/action-releaser/entrypoint.sh
@@ -81,7 +81,7 @@ lookup_changed_actions() {
     # merge commits have multiple parents, use '^@' to fetch all parents of the merge
     # use variable to handle newline in git-rev-parse output
     local commit_sha
-    commit_sha=$(git rev-parse HEAD HEAD^@)
+    commit_sha=$(git rev-parse HEAD^@)
     einfo "Commits fetched: $(echo $commit_sha | tr ' ' ';')"
 
     local changed_files

--- a/actions/action-releaser/entrypoint.sh
+++ b/actions/action-releaser/entrypoint.sh
@@ -78,10 +78,14 @@ filter_actions() {
 
 lookup_changed_actions() {
     # look for changed files in the latest commit
-    # merge commits have multiple parents, use '^@' to fetch all parents of the merge
-    # use variable to handle newline in git-rev-parse output
+
+    # Merge commits: have multiple parents, fetch all parents of HEAD
+    # Other commits: fetch only current HEAD
     local commit_sha
     commit_sha=$(git rev-parse HEAD^@)
+    if [ $(echo $commit_sha | wc -w) -eq 1 ]; then
+        commit_sha=$(git rev-parse HEAD)
+    fi
     einfo "Commits fetched: $(echo $commit_sha | tr ' ' ';')"
 
     local changed_files

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -49,7 +49,7 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-# get latest tag that looks like a semver (with or without v, using with_v)
+# get latest tag & version that looks like a semver (with or without v, using with_v)
 if $with_v; then
     tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
     version_pattern="(.*)v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -49,7 +49,7 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-# get latest tag & version that looks like a semver (with or without v, using with_v)
+# get latest tag and version that looks like a semver (with or without v, using with_v)
 if $with_v; then
     tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
     version_pattern="(.*)v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"


### PR DESCRIPTION
Problem statement - merge commits and non-merge commits needs to be handled differently to identify changed files

merge commits 
```
github-actions (mergeCommit) >> git rev-parse --short HEAD
c938d94

github-actions (mergeCommit) >> git rev-parse  HEAD
c938d94263b4d2db69d18be3ba675410891434ef

github-actions (mergeCommit) >> git log --oneline HEAD
c938d94 (HEAD -> mergeCommit, origin/dexamundsen/mastercopy) Merge pull request #38 from DataBiosphere/dexamundsen/fix-5
f43b5fc (origin/mcopy, origin/dexamundsen/fix-5, directCommit, dexamundsen/fix-5) revert #37
5e4c681 (origin/master, origin/HEAD, master) Merge pull request #37 from DataBiosphere/dexamundsen/fix-4

github-actions (mergeCommit) >>  git cat-file -p c938d94
tree de246f9eb2f226c3aa28c84eaac5f6c7188d6119
parent 5e4c6818655d51d44793977af6117dbd8d226ebf 
parent f43b5fc916ba5fdf72b9b0866cedf6050c91ccd5
author Dexter Amundsen <dexamundsen@verily.com> 1679402410 -0700
committer GitHub <noreply@github.com> 1679402410 -0700
gpgsig -----BEGIN PGP SIGNATURE-----
…..
 -----END PGP SIGNATURE-----
Merge pull request #38 from DataBiosphere/dexamundsen/fix-5
revert #37

github-actions (mergeCommit) >> git rev-parse --short HEAD^@
5e4c681
f43b5fc

github-actions (mergeCommit) >> git rev-parse  HEAD^@
5e4c6818655d51d44793977af6117dbd8d226ebf
f43b5fc916ba5fdf72b9b0866cedf6050c91ccd5

github-actions (mergeCommit) >> git log --oneline HEAD^@
f43b5fc (origin/mcopy, origin/dexamundsen/fix-5, directCommit, dexamundsen/fix-5) revert #37
5e4c681 (origin/master, origin/HEAD, master) Merge pull request #37 from DataBiosphere/dexamundsen/fix-4
```

direct commit (non-merge)
```
github-actions (directCommit) >> git rev-parse --short HEAD
f43b5fc

github-actions (directCommit) >> git rev-parse  HEAD
f43b5fc916ba5fdf72b9b0866cedf6050c91ccd5

github-actions (directCommit) >> git log --oneline HEAD
f43b5fc (HEAD -> directCommit, origin/mcopy, origin/dexamundsen/fix-5, dexamundsen/fix-5) revert #37
5e4c681 (origin/master, origin/HEAD, master) Merge pull request #37 from DataBiosphere/dexamundsen/fix-4
e5e7d44 (origin/dexamundsen/fix-4) Add current commit sha to parent sha list to fetch changed files

github-actions (directCommit) >>  git cat-file -p f43b5fc
tree de246f9eb2f226c3aa28c84eaac5f6c7188d6119
parent 5e4c6818655d51d44793977af6117dbd8d226ebf
author Dex Amundsen <dexamundsen@verily.com> 1679400252 -0700
committer Dex Amundsen <dexamundsen@verily.com> 1679400252 -0700
revert #37

github-actions (directCommit) >> git rev-parse --short HEAD^@
5e4c681

github-actions (directCommit) >> git rev-parse  HEAD^@
5e4c6818655d51d44793977af6117dbd8d226ebf

github-actions (directCommit) >> git log --oneline HEAD^@
5e4c681 (origin/master, origin/HEAD, master) Merge pull request #37 from DataBiosphere/dexamundsen/fix-4
e5e7d44 (origin/dexamundsen/fix-4) Add current commit sha to parent sha list to fetch changed files
```

testing - 

merge commits 
```
github-actions (mergeCommit) >> commit_sha=$(git rev-parse HEAD^@)
github-actions (mergeCommit) >> echo $commit_sha
5e4c6818655d51d44793977af6117dbd8d226ebf f43b5fc916ba5fdf72b9b0866cedf6050c91ccd5
github-actions (mergeCommit) >> if [ $(echo $commit_sha | wc -w) -eq 1 ]; then         commit_sha=$(git rev-parse HEAD);     fi;
github-actions (mergeCommit) >> echo $commit_sha
5e4c6818655d51d44793977af6117dbd8d226ebf f43b5fc916ba5fdf72b9b0866cedf6050c91ccd5
github-actions (mergeCommit) >> git diff-tree --no-commit-id --name-only -r $commit_sha -- actions
actions/action-releaser/entrypoint.sh
actions/bumper/entrypoint.sh
```

direct commit (non-merge)
```
github-actions (directCommit) >> commit_sha=$(git rev-parse HEAD^@)
github-actions (directCommit) >> echo $commit_sha
5e4c6818655d51d44793977af6117dbd8d226ebf
github-actions (directCommit) >> if [ $(echo $commit_sha | wc -w) -eq 1 ]; then         commit_sha=$(git rev-parse HEAD);     fi;
github-actions (directCommit) >> echo $commit_sha
f43b5fc916ba5fdf72b9b0866cedf6050c91ccd5
github-actions (directCommit) >> git diff-tree --no-commit-id --name-only -r $commit_sha -- actions
actions/action-releaser/entrypoint.sh
actions/bumper/entrypoint.sh
```