### PR TITLE
Fix error in lookup_latest_tag

### DIFF
--- a/actions/action-releaser/entrypoint.sh
+++ b/actions/action-releaser/entrypoint.sh
@@ -61,7 +61,7 @@ lookup_latest_tag() {
     git fetch --tags > /dev/null 2>&1
 
     edebug "Looking for latest tag for $action"
-    git for-each-ref --sort=-taggerdate --count=1 --format '%(refname:lstrip=-1)' "refs/tags/$action-*"
+    git for-each-ref --sort=-committerdate --count=1 --format '%(refname:lstrip=-1)' "refs/tags/$action-*"
 }
 
 filter_actions() {
@@ -109,7 +109,8 @@ tag_action() {
     local version="$2"
     local tag="$action-$version"
 
-    einfo "Creating tag '$tag'"
+    # lightweight tags do not have taggerdate set
+    einfo "Creating lightweight tag '$tag'"
     git tag "$tag"
 }
 

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -49,7 +49,7 @@ echo "pre_release = $pre_release"
 # fetch tags
 git fetch --tags
 
-# get latest tag and version that looks like a semver (with or without v, using with_v)
+# get latest tag & version that looks like a semver (with or without v, using with_v)
 if $with_v; then
     tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
     version_pattern="(.*)v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"


### PR DESCRIPTION
There is a error in lookup_latest_tag - existing tags are sorted by taggerDate (desc), but the leightweight tags created do not have this field set
fix - 
- Option 1: create regular / annotated tags with `-a` option. This is not backward compatible with existing tags
- [chosen] Option 2: use `creatordate` or `committerdate` to sort existing tags instead. Backward compatible. Use `committerdate` here since in general we want this in order of commit

error surfaced here - 
https://github.com/DataBiosphere/github-actions/actions/runs/4482722782/jobs/7881120619
```
Cloning into 'github-actions'...
2023-03-21 18:47:[13](https://github.com/DataBiosphere/github-actions/actions/runs/4482722782/jobs/7881120619#step:3:14) - INFO ---- Discovering changed actions ...
2023-03-21 18:47:13 - INFO ---- Commits fetched: 5e4c6818655d51d44793977af6117dbd8d226ebf;cdf6ee54679290ec2a3a4f803104acf025a7bddb
2023-03-21 18:47:13 - INFO ---- Changed files: actions/action-releaser/entrypoint.sh;actions/bumper/entrypoint.sh
2023-03-21 18:47:13 - INFO ---- Updating action.yml of action-releaser to point to the '0.1.0' tag
[master 8281cb2] Updating action.yml of action-releaser to point to the '0.1.0' tag
 1 file changed, 1 insertion(+), 1 deletion(-)
2023-03-21 18:47:13 - INFO ---- Creating tag 'action-releaser-0.1.0'
fatal: tag 'action-releaser-0.1.0' already exists
```

without changes
```
github-actions (dexamundsen/fix-6) >> git fetch --tags > /dev/null 2>&1
github-actions (dexamundsen/fix-6) >> git for-each-ref --sort=-taggerdate --format '%(taggerdate)' | uniq

github-actions (dexamundsen/fix-6) >> git for-each-ref --sort=-taggerdate --format '%(refname) %(taggerdate)' refs/tags/action-releaser-*
refs/tags/action-releaser-0.0.0 
refs/tags/action-releaser-0.1.0 
refs/tags/action-releaser-0.2.0 
refs/tags/action-releaser-0.3.0 
refs/tags/action-releaser-0.4.0 
refs/tags/action-releaser-0.5.0 
refs/tags/action-releaser-0.6.0 
github-actions (dexamundsen/fix-6) >> git for-each-ref --sort=-taggerdate --count=1 --format '%(refname:lstrip=-1)' refs/tags/action-releaser-*
action-releaser-0.0.0
```
with changes
```
github-actions (dexamundsen/fix-6) >> git for-each-ref --sort=-committerdate --format '%(refname) %(committerdate)' refs/tags/action-releaser-*
refs/tags/action-releaser-0.6.0 Wed Nov 25 19:16:43 2020 +0000
refs/tags/action-releaser-0.5.0 Wed Nov 25 19:11:35 2020 +0000
refs/tags/action-releaser-0.4.0 Wed Nov 25 19:04:58 2020 +0000
refs/tags/action-releaser-0.3.0 Wed Nov 25 18:20:42 2020 +0000
refs/tags/action-releaser-0.2.0 Mon Sep 28 11:54:36 2020 -0400
refs/tags/action-releaser-0.1.0 Tue Sep 22 18:13:55 2020 -0400
refs/tags/action-releaser-0.0.0 Tue Sep 22 15:55:56 2020 -0400
github-actions (dexamundsen/fix-6) >> git for-each-ref --sort=-committerdate --count=1 --format '%(refname:lstrip=-1)' refs/tags/action-releaser-*
action-releaser-0.6.0
```
