### PR TITLE
Use same logic to fetch latest tag in bumper as in action-releaser

### DIFF
--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -51,15 +51,15 @@ git fetch --tags
 
 # get latest tag & version that looks like a semver (with or without v, using with_v)
 if $with_v; then
-    tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
+    tag_pattern="v[0-9]*.[0-9]*.[0-9]*"
     version_pattern="(.*)v([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
 else
-    tag_pattern="refs/tags/[0-9]*.[0-9]*.[0-9]*"
+    tag_pattern="[0-9]*.[0-9]*.[0-9]*"
     version_pattern="(.*)([0-9]+\.[0-9]+\.[0-9]+-?[a-zA-Z0-9]*)(.*)"
 fi
 
 case "$tag_context" in
-    *repo*) tag=$(git for-each-ref --sort=-v:refname --count=1 --format '%(refname)' "$tag_pattern" | cut -d / -f 3-);;
+    *repo*) tag=$(git for-each-ref --sort=-committerdate --count=1 --format '%(refname)' "refs/tags/$tag_pattern" | cut -d / -f 3-);;
     *branch*) tag=$(git describe --tags --match "*[v0-9].*[0-9\.]" --abbrev=0);;
     * ) echo "Unrecognised context"; exit 1;;
 esac


### PR DESCRIPTION
Problem statement - In bumper the latest release is (inaccurately) identified by sorting the tags by refname alphabetically. RefNames may be generated outside bumper and alpabetical sorting may not fetch the latest 

Proposed fix - use the same logic to fetch the latest tag in bumper as in action-releaser

Testing - 

current logic - 
```
github-actions (dexamundsen/bumper-date) >> tag_pattern="refs/tags/v[0-9]*.[0-9]*.[0-9]*"
github-actions (dexamundsen/bumper-date) >> git for-each-ref --sort=-v:refname --count=1 --format '%(refname)' "$tag_pattern"
refs/tags/v0.0.3
github-actions (dexamundsen/bumper-date) >> git for-each-ref --sort=-v:refname --count=1 --format '%(refname)' "$tag_pattern" | cut -d / -f 3-
v0.0.3
```

changed logic
```
github-actions (dexamundsen/bumper-date) >> tag_pattern="v[0-9]*.[0-9]*.[0-9]*"
github-actions (dexamundsen/bumper-date) >> git for-each-ref --sort=-committerdate --count=1 --format '%(refname)' "refs/tags/$tag_pattern"
refs/tags/v0.0.3
github-actions (dexamundsen/bumper-date) >> git for-each-ref --sort=-committerdate --count=1 --format '%(refname)' "refs/tags/$tag_pattern" | cut -d / -f 3-
v0.0.3
```