### PR TITLE
AJ-1095 - Enable updating multiple version files in one bump action 

### DIFF
--- a/actions/bumper/README.md
+++ b/actions/bumper/README.md
@@ -49,8 +49,8 @@ jobs:
 * **DRY_RUN** *(optional)* - Determine the next version without tagging the branch. The workflow can use the outputs `new_tag` and `tag` in subsequent steps. Possible values are ```true``` and ```false``` (default).
 * **INITIAL_VERSION** *(optional)* - Set initial version before bump. Default `0.0.0`.
 * **TAG_CONTEXT** *(optional)* - Set the context of the previous tag. Possible values are `repo` (default) or `branch`.
-* **VERSION_FILE_PATH** *(optional)* - If present, update the version number in that file
-* **VERSION_LINE_MATCH** *(optional)* - If present, a grep regular expression to identify the line containing the version number in the VERSION_FILE_PATH.
+* **VERSION_FILE_PATH** *(optional)* - If present, update the version number each file listed (can provide multiple files separated by a comma) Examples: `build.gradle` or `build.gradle,settings.gradle`
+* **VERSION_LINE_MATCH** *(optional)* - If present, a grep regular expression to identify the line containing the version number in the VERSION_FILE_PATH. If multiple file paths are provided, list the same number of regular expressions comma separated in the same order as presented in VERSION_FILE_PATH. Note: regular expressions containing commas will not work. 
 * **VERSION_SUFFIX** *(optional)* - Suffix added to the version in the version file, such as, -SNAPSHOT
 
 #### Outputs

--- a/actions/bumper/action.yml
+++ b/actions/bumper/action.yml
@@ -3,7 +3,7 @@ description: 'Bump and push git tag on merge'
 author: 'Nick Sjostrom'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/bumper:0.2.0
 outputs:
   new_tag:
     description: 'Generated tag'

--- a/actions/bumper/action.yml
+++ b/actions/bumper/action.yml
@@ -3,7 +3,7 @@ description: 'Bump and push git tag on merge'
 author: 'Nick Sjostrom'
 runs:
   using: 'docker'
-  image: docker://us-central1-docker.pkg.dev/dsp-artifact-registry/github-actions-public/bumper:0.2.0
+  image: 'Dockerfile'
 outputs:
   new_tag:
     description: 'Generated tag'

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -196,11 +196,14 @@ else
         version_line_match_i=${line_match[$i]}
         echo "Updating $version_file_path_i located at $version_line_match_i"
         
+        echo $(cat $version_file_path_i)
         version_line=$(cat $version_file_path_i | grep -e "${version_line_match_i}")
+        echo "Version line: ${version_line}"
         if [ -z "$version_line" ]; then
             echo "No version line found; no bump of version file."
         else
             new_line=$(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
+            echo "New version line: ${new_line}"
             sed -E -i.bak -e "s/${version_line}/${new_line}/" $fp
         fi
         git add $version_file_path_i

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -196,14 +196,11 @@ else
         version_line_match_i=${line_match[$i]}
         echo "Updating $version_file_path_i located at $version_line_match_i"
         
-        echo $(cat $version_file_path_i)
         version_line=$(cat $version_file_path_i | grep -e "${version_line_match_i}")
-        echo "Version line: ${version_line}"
         if [ -z "$version_line" ]; then
             echo "No version line found; no bump of version file."
         else
             new_line=$(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
-            echo "New version line: ${new_line}"
             sed -E -i.bak -e "s/${version_line}/${new_line}/" $version_file_path_i
         fi
         git add $version_file_path_i

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -204,7 +204,7 @@ else
         else
             new_line=$(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
             echo "New version line: ${new_line}"
-            sed -E -i.bak -e "s/${version_line}/${new_line}/" $fp
+            sed -E -i.bak -e "s/${version_line}/${new_line}/" $version_file_path_i
         fi
         git add $version_file_path_i
     done

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -185,16 +185,27 @@ else
         version_new=${new}-${version_suffix}
     fi
 
-    version_line=$(cat $version_file_path | grep -e "${version_line_match}")
-    if [ -z "$version_line" ]; then
-        echo "No version line found; no bump of version file."
-    else
-        new_line=$(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
-        sed -E -i.bak -e "s/${version_line}/${new_line}/" $version_file_path
-    fi
     git config --global user.email "robot@terra.team"
     git config --global user.name "bumptagbot"
-    git add $version_file_path
+
+    # check for multiple version file paths to update
+    IFS=',' read -ra file_path <<< "$version_file_path"
+    IFS=',' read -ra line_match <<< "$version_line_match"
+    for i in "${!file_path[@]}"; do
+        version_file_path_i=${file_path[$i]}
+        version_line_match_i=${line_match[$i]}
+        echo "Updating $version_file_path_i located at $version_line_match_i"
+        
+        version_line=$(cat $version_file_path_i | grep -e "${version_line_match_i}")
+        if [ -z "$version_line" ]; then
+            echo "No version line found; no bump of version file."
+        else
+            new_line=$(echo "$version_line" | sed -E -e "s/$version_pattern/\1${version_new}\3/")
+            sed -E -i.bak -e "s/${version_line}/${new_line}/" $fp
+        fi
+        git add $version_file_path_i
+    done
+  
     git commit -m "bump ${new}"
     git push origin $current_branch
     commit=$(git rev-parse HEAD)


### PR DESCRIPTION
Enabling updating the version in multiple files. 
Example usage:
<img width="636" alt="image" src="https://github.com/DataBiosphere/github-actions/assets/13254229/5bd8f1ca-4b93-4382-9645-2f2dc407fdd0">

Example resulting update:
<img width="879" alt="image" src="https://github.com/DataBiosphere/github-actions/assets/13254229/f75cb824-ce2d-491d-9ffa-4b8f006e4770">


Caveat: Any commas in the regex for matching the file location would break with these changes because we split the list of version files on commas. 
