### PR TITLE
add FORCE_WITHOUT_CHANGES option to bumper

### DIFF
--- a/actions/bumper/README.md
+++ b/actions/bumper/README.md
@@ -52,6 +52,7 @@ jobs:
 * **VERSION_FILE_PATH** *(optional)* - If present, update the version number in that file
 * **VERSION_LINE_MATCH** *(optional)* - If present, a grep regular expression to identify the line containing the version number in the VERSION_FILE_PATH.
 * **VERSION_SUFFIX** *(optional)* - Suffix added to the version in the version file, such as, -SNAPSHOT
+* **FORCE_WITHOUT_CHANGES** *(optional)* - Bump even if there are no changes from the previous version.
 
 #### Outputs
 

--- a/actions/bumper/entrypoint.sh
+++ b/actions/bumper/entrypoint.sh
@@ -14,6 +14,7 @@ version_file_path=${VERSION_FILE_PATH}
 version_line_match=${VERSION_LINE_MATCH}
 version_suffix=${VERSION_SUFFIX}
 hotfix_version=${HOTFIX_VERSION}
+force_without_changes=${FORCE_WITHOUT_CHANGES:-false}
 
 cd ${GITHUB_WORKSPACE}/${source}
 git config --global --add safe.directory $(pwd)
@@ -80,7 +81,7 @@ tag_commit=$(git rev-list -n 1 $tag)
 # get current commit hash
 commit=$(git rev-parse HEAD)
 
-if [ "$tag_commit" == "$commit" ]; then
+if [ "$tag_commit" == "$commit" ] && [ "$force_without_changes" == "false" ]; then
     echo "No new commits since previous tag. Skipping..."
     echo tag=$tag >> $GITHUB_OUTPUT
     exit 0


### PR DESCRIPTION
This adds the `FORCE_WITHOUT_CHANGES` option from the [upstream](https://github.com/anothrNick/github-tag-action/tree/master), without attempting to merge all of the latest changes in.

The version in this repo and the upstream are pretty far apart at this point. While it would be beneficial to catch them up, that's a much larger lift - so, I'm incrementally adding the feature I really want.